### PR TITLE
More v0.7 updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
+  - 1.0
   - nightly
 matrix:
     allow_failures:
@@ -13,7 +13,5 @@ matrix:
 notifications:
   email: false
 after_success:
-  - julia -e 'Pkg.add("Documenter", v"0.6.0")'
-  - julia -e 'cd(Pkg.dir("FastaIO")); include(joinpath("docs", "make.jl"))'
-  - julia -e 'Pkg.add("Coverage", v"0.3")'
-  - julia -e 'cd(Pkg.dir("FastaIO")); include(joinpath("docs", "coverage.jl"))'
+  - julia -e 'using Pkg, FastaIO; Pkg.add("Documenter"); include(joinpath("docs", "make.jl"))'
+  - julia -e 'using Pkg, FastaIO; Pkg.add("Coverage"); using Coverage; get(ENV,"TRAVIS_OS_NAME","")=="linux" && get(ENV,"TRAVIS_JULIA_VERSION","")=="0.7" && Codecov.submit(Codecov.process_folder())'

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 | **Documentation**                                                               | **PackageEvaluator**                                            | **Build Status**                                                                                |
 |:-------------------------------------------------------------------------------:|:---------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-latest-img]][docs-latest-url] | [![][pkg-0.6-img]][pkg-0.6-url] [![][pkg-0.7-img]][pkg-0.7-url] | [![][travis-img]][travis-url] [![][appveyor-img]][appveyor-url] [![][codecov-img]][codecov-url] |
 
 Utilities to read/write FASTA format files in [Julia].
 
@@ -45,7 +45,7 @@ See also the examples in the `examples/` directory.
 [codecov-img]: https://codecov.io/gh/carlobaldassi/FastaIO.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/carlobaldassi/FastaIO.jl
 
-[pkg-0.5-img]: http://pkg.julialang.org/badges/FastaIO_0.5.svg
-[pkg-0.5-url]: http://pkg.julialang.org/?pkg=FastaIO
 [pkg-0.6-img]: http://pkg.julialang.org/badges/FastaIO_0.6.svg
-[pkg-0.6-url]: http://pkg.julialang.org/?pkg=FastaIO
+[pkg-0.6-url]: http://pkg.julialang.org/?pkg=FastaIO&ver=0.6
+[pkg-0.7-img]: http://pkg.julialang.org/badges/FastaIO_0.7.svg
+[pkg-0.7-url]: http://pkg.julialang.org/?pkg=FastaIO&ver=0.7

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
-julia 0.6
-Compat 0.59
-GZip 0.2.20
+julia 0.7
+GZip 0.5

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,16 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.7/julia-0.7-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.7/julia-0.7-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1.0
+  - julia_version: latest
 
-branches:
-  only:
-    - master
-    - /release-.*/
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
 
 matrix:
   allow_failures:
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-    - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+    - julia_version: latest
 
 notifications:
   - provider: Email
@@ -23,25 +18,18 @@ notifications:
     on_build_failure: false
     on_build_status_changed: false
 
+branches:
+  only:
+    - master
+    - /release-.*/
+
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"FastaIO\"); Pkg.build(\"FastaIO\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia --check-bounds=yes -e "Pkg.test(\"FastaIO\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"

--- a/docs/coverage.jl
+++ b/docs/coverage.jl
@@ -1,7 +1,0 @@
-# Only run coverage from linux release build on travis.
-get(ENV, "TRAVIS_OS_NAME", "")       == "linux" || exit()
-get(ENV, "TRAVIS_JULIA_VERSION", "") == "0.6"   || exit()
-
-using Coverage
-
-Codecov.submit(Codecov.process_folder())

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,5 +14,5 @@ deploydocs(
     target = "build",
     deps = nothing,
     make = nothing,
-    julia  = "0.6"
+    julia  = "0.7"
 )

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -109,10 +109,6 @@ readentry
 ```
 
 ```@docs
-readstring(::FastaReader)
-```
-
-```@docs
 rewind(::FastaReader)
 ```
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,4 +1,4 @@
-# FastaIO.jl — FASTA file reader and writed module
+# FastaIO.jl — FASTA file reader and writer module
 
 ```@meta
 CurrentModule = FastaIO

--- a/src/FastaIO.jl
+++ b/src/FastaIO.jl
@@ -15,7 +15,7 @@ using GZip
 
 export
     FastaReader,
-    readentry, readentries,
+    readentry,
     rewind,
     readfasta,
     FastaWriter,
@@ -80,7 +80,7 @@ type is set when creating the `FastaReader` object (e.g. `FastaReader{Vector{UIn
 
 The `FastaReader` type has a field `num_parsed` which contains the number of entries parsed so far.
 
-Other ways to read out the data are via the [`readentry`](@ref) and [`readentries`](@ref) functions.
+Other ways to read out the data are via the [`readentry`](@ref) and [`readfasta`](@ref) functions.
 """
 FastaReader(file::Union{AbstractString,IO}) = FastaReader{String}(file)
 
@@ -263,15 +263,6 @@ function iterate(fr::FastaReader, x::Nothing)
 end
 
 """
-    readentries(fr::FastaReader)
-
-Parses the whole FASTA file at once and returns an array of
-tuples, each one containing the description and the sequence
-(see also the [`readfasta`](@ref) function).
-"""
-readentries(fr::FastaReader) = collect(fr)
-
-"""
     readentry(fr::FastaReader)
 
 This function can be used to read entries one at a time:
@@ -326,7 +317,7 @@ the `sequence_type` optional argument (see [The sequence storage type](@ref) sec
 """
 readfasta(filename::AbstractString, ::Type{T}=String) where T =
     gzopen(io -> readfasta(io, T), filename)
-readfasta(io::IO, ::Type{T}=String) where T = readentries(FastaReader{T}(io))
+readfasta(io::IO, ::Type{T}=String) where T = collect(FastaReader{T}(io))
 
 mutable struct FastaWriter
     f::IO

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,8 +59,8 @@ const fastadata_char = map(x->(x[1],Vector{Char}(x[2])), fastadata_ascii)
 
 function test_fastaread(T::Type, infile, fastadata)
     FastaReader(infile, T) do fr
-    @testset "readentries(fr)" begin
-        @test readentries(fr) == fastadata
+    @testset "collect(fr)" begin
+        @test collect(fr) == fastadata
     end
 
         rewind(fr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,12 +2,7 @@ module FastaTests
 
 using FastaIO
 using GZip
-using Compat
-if VERSION < v"0.7.0-DEV.1995"
-    using Base.Test
-else
-    using Test
-end
+using Test
 
 const fastadata_ascii = Any[
     ("A0ADS9_STRAM/3-104",

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -59,7 +59,7 @@ const fastadata_char = map(x->(x[1],Vector{Char}(x[2])), fastadata_ascii)
 
 function test_fastaread(T::Type, infile, fastadata)
     FastaReader(infile, T) do fr
-        @test readstring(fr) == fastadata
+        @test readentries(fr) == fastadata
 
         rewind(fr)
 


### PR DESCRIPTION
* drop support for prerelease versions of Julia v0.7
* enable CI testing on 0.7 & 1.0
* update badges
* annotate tests with testsets
* improve support for `iterate()` protocol (define `IteratorSize` and `eltype()`)
* `readstring` was removed from Julia v1.0 (replaced by `read(io, String)`), making the same change in FastaIO would be confusing (FastaIO method is not doing what `read(io, String)` is supposed to do), so I renamed `readstring()` into an exported method `readentries()`