### PR TITLE
bump GZip compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,13 +1,13 @@
 name = "FastaIO"
 uuid = "a0c94c4b-ebed-5953-b5fc-82fe598ac79f"
-version = "1.0.0"
 author = ["Carlo Baldassi <carlobaldassi@gmail.com>"]
+version = "1.0.1"
 
 [deps]
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
 
 [compat]
-GZip = "0.5"
+GZip = "0.5,0.6"
 julia = "1"
 
 [extras]

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,3 @@
 [deps]
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
-
-[compat]
-GZip = "0.5"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
This was holding back some other dependencies for me. Tests pass, so it seems compatible with GZip v0.6.