### PR TITLE
Add check_description flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,6 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           files: lcov.info

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov: 
+ token: b60713dd-5429-4e88-8a1e-d3a1f45a34f6

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -72,8 +72,8 @@ The FASTA format which is assumed by this module is as follows:
    at the beginning or end of the description
 5. Empty lines are ignored (note however that lines containing whitespace will still trigger an error)
 
-When writing, description lines longer than 80 characters will trigger a warning message; sequence data is
-formatted in lines of 80 characters each; extra whitespace is silently discarded.
+When writing, description lines longer than 80 characters will trigger a warning message (this can be optionally
+disabled); sequence data is formatted in lines of 80 characters each; extra whitespace is silently discarded.
 No other restriction is put on the content of the sequence data, except that the `>` character is
 forbidden.
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,3 +1,4 @@
 [deps]
 GZip = "92fee26a-97fe-5a0c-ad85-20a5f3185b63"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Allows to suppress the description length warning.
Closes #14